### PR TITLE
Bug fixed: high performance seed unit was wrong.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,13 @@
 PROG = ezio
-STATIC_PROG = static-$(PROG)
+STATIC_PROG = $(PROG)-static
 
 CC =
 CXX = g++
 LD = g++
-CXXFLAGS = -std=c++11 -I./
+CXXFLAGS = -g -std=c++11 -I./
 LDFLAGS = -ltorrent-rasterbar -lboost_system -lpthread -lstdc++ -lm -lgcc -lssl -lcrypto -lboost_chrono -lboost_random -ldl
+prefix = $(DESTDIR)/usr
+sbindir = $(prefix)/sbin
 
 OBJS = main.o
 INC = 
@@ -20,7 +22,7 @@ $(PROG): $(OBJS) $(INC)
 	$(LD) -o $(PROG) $(OBJS) $(LDFLAGS) $(CXXFLAGS)
 
 $(STATIC_PROG): $(OBJS) $(INC)
-	$(LD) -static -o $(STATIC_PROG) $(OBJS) $(LDFLAGS) $(CXXFLAGS)
+	$(LD) -static -pthread -o $(STATIC_PROG) $(OBJS) $(LDFLAGS) $(CXXFLAGS)
 	strip -s $(STATIC_PROG)
 
 .cpp.o:
@@ -34,3 +36,8 @@ clean:
 .PHONY: netboot
 netboot: static
 	make -C utils all
+
+install:
+	mkdir -p $(sbindir)
+	install -m 755 ezio $(sbindir)/
+	install -m 755 ezio-static $(sbindir)/

--- a/main.cpp
+++ b/main.cpp
@@ -196,7 +196,7 @@ struct temp_storage : lt::storage_interface {
 
 lt::storage_interface* raw_storage_constructor(lt::storage_params const& params)
 {
-	return new raw_storage(*params.files, params.path);
+	return new temp_storage(*params.files, params.path);
 }
 
 void usage()
@@ -278,7 +278,7 @@ int main(int argc, char ** argv)
 	else{
 		atp.url = bt_info;
 	}
-	atp.storage = temp_storage_constructor;
+	atp.storage = raw_storage_constructor;
 
 	lt::torrent_handle handle = ses.add_torrent(atp);
 	handle.set_max_uploads(max_upload_ezio);

--- a/main.cpp
+++ b/main.cpp
@@ -354,7 +354,7 @@ int main(int argc, char ** argv)
 			<< "[D: " << std::setprecision(2) << (float)status.download_payload_rate / 1024 / 1024 /1024 * 60 << " GB/min] "
 			<< "[T: " << (int)status.active_time  << " secs] "
 			*/
-			<< "[U: " << std::setprecision(2) << (float)status.upload_payload_rate / 1024 / 1024 /1024 * 60 << " MB/min] "
+			<< "[U: " << std::setprecision(2) << (float)status.upload_payload_rate / 1024 / 1024 /1024 * 60 << " GB/min] "
 			<< "[T: " << (int)status.seeding_time  << " secs] "
 			<< std::flush;
 


### PR DESCRIPTION
1. Bug fixed: high performance seed unit was wrong: MB/sec -> GB/sec.
2. Change corresponding names for storage constructor.
3. Make static link work on Debian Sid.